### PR TITLE
Pref fixes

### DIFF
--- a/core/po/ar.po
+++ b/core/po/ar.po
@@ -506,11 +506,11 @@ msgid "Draw atom numbers"
 msgstr "أرسُم أرقام الذرّات"
 
 #: src/main/org/openscience/jchempaint/dialog/editor/PropertiesModelEditor.java:181
-msgid "Explicit carbons"
+msgid "All Carbons Explicit"
 msgstr "ذرّات كربون غير ضمنية"
 
 #: src/main/org/openscience/jchempaint/dialog/editor/PropertiesModelEditor.java:185
-msgid "Show explicit methyl groups"
+msgid "Terminal Carbons Explicit"
 msgstr "أظهِر مجموعات الميثيل الغير ضمنية"
 
 #: src/main/org/openscience/jchempaint/dialog/editor/PropertiesModelEditor.java:189
@@ -557,16 +557,16 @@ msgid "Atom size"
 msgstr "حجم الذرّة"
 
 #: src/main/org/openscience/jchempaint/dialog/editor/PropertiesModelEditor.java:261
-msgid "Bond width"
+msgid "Bond Width"
 msgstr "عرض الرّابطة"
 
 #: src/main/org/openscience/jchempaint/dialog/editor/PropertiesModelEditor.java:280
 #, fuzzy
-msgid "Highlight/Select diameter"
+msgid "Highlight Distance"
 msgstr "أبرِز البُعد"
 
 #: src/main/org/openscience/jchempaint/dialog/editor/PropertiesModelEditor.java:290
-msgid "Wedge width"
+msgid "Wedge Width"
 msgstr "عرض الوتَد"
 
 #: src/main/org/openscience/jchempaint/dialog/editor/PropertiesModelEditor.java:305
@@ -2867,7 +2867,7 @@ msgstr "لا تراجُع ممكِن"
 #~ msgid "Font name"
 #~ msgstr "اسم الخط"
 
-#~ msgid "Choose Color..."
+#~ msgid "Choose"
 #~ msgstr "إنتقِ لونًا..."
 
 #~ msgid "Choose a Font"

--- a/core/po/ca.po
+++ b/core/po/ca.po
@@ -507,11 +507,11 @@ msgid "Draw atom numbers"
 msgstr "Mostra la numeració dels àtoms"
 
 #: src/main/org/openscience/jchempaint/dialog/editor/PropertiesModelEditor.java:181
-msgid "Explicit carbons"
+msgid "All Carbons Explicit"
 msgstr "Carbonis explícits"
 
 #: src/main/org/openscience/jchempaint/dialog/editor/PropertiesModelEditor.java:185
-msgid "Show explicit methyl groups"
+msgid "Terminal Carbons Explicit"
 msgstr "Mostra els grups metil explícits"
 
 #: src/main/org/openscience/jchempaint/dialog/editor/PropertiesModelEditor.java:189
@@ -556,15 +556,15 @@ msgid "Atom size"
 msgstr "Mida dels àtoms"
 
 #: src/main/org/openscience/jchempaint/dialog/editor/PropertiesModelEditor.java:261
-msgid "Bond width"
+msgid "Bond Width"
 msgstr "Gruix de l'enllaç"
 
 #: src/main/org/openscience/jchempaint/dialog/editor/PropertiesModelEditor.java:280
-msgid "Highlight/Select diameter"
+msgid "Highlight Distance"
 msgstr "Diàmetre del cercle ressaltat de selecció"
 
 #: src/main/org/openscience/jchempaint/dialog/editor/PropertiesModelEditor.java:290
-msgid "Wedge width"
+msgid "Wedge Width"
 msgstr "Amplada de les falques"
 
 #: src/main/org/openscience/jchempaint/dialog/editor/PropertiesModelEditor.java:305

--- a/core/po/cs.po
+++ b/core/po/cs.po
@@ -510,11 +510,11 @@ msgid "Draw atom numbers"
 msgstr "Zobrazit atomová čísla"
 
 #: src/main/org/openscience/jchempaint/dialog/editor/PropertiesModelEditor.java:181
-msgid "Explicit carbons"
+msgid "All Carbons Explicit"
 msgstr "Zobrazovat uhlíky explicitně"
 
 #: src/main/org/openscience/jchempaint/dialog/editor/PropertiesModelEditor.java:185
-msgid "Show explicit methyl groups"
+msgid "Terminal Carbons Explicit"
 msgstr "Zobrazovat metylové skupiny explicitně"
 
 #: src/main/org/openscience/jchempaint/dialog/editor/PropertiesModelEditor.java:189
@@ -558,15 +558,15 @@ msgid "Atom size"
 msgstr "Velikost atomu"
 
 #: src/main/org/openscience/jchempaint/dialog/editor/PropertiesModelEditor.java:261
-msgid "Bond width"
+msgid "Bond Width"
 msgstr "Šířka vazby"
 
 #: src/main/org/openscience/jchempaint/dialog/editor/PropertiesModelEditor.java:280
-msgid "Highlight/Select diameter"
+msgid "Highlight Distance"
 msgstr ""
 
 #: src/main/org/openscience/jchempaint/dialog/editor/PropertiesModelEditor.java:290
-msgid "Wedge width"
+msgid "Wedge Width"
 msgstr "Šířka klínu"
 
 #: src/main/org/openscience/jchempaint/dialog/editor/PropertiesModelEditor.java:305
@@ -2798,7 +2798,7 @@ msgstr "Nelze vzít zpět"
 #~ msgid "Font name"
 #~ msgstr "Název písma"
 
-#~ msgid "Choose Color..."
+#~ msgid "Choose"
 #~ msgstr "Vybrat barvu..."
 
 #~ msgid "BACKCOLOR"

--- a/core/po/de.po
+++ b/core/po/de.po
@@ -498,11 +498,11 @@ msgid "Draw atom numbers"
 msgstr "Atomnummern zeichnen"
 
 #: src/main/org/openscience/jchempaint/dialog/editor/PropertiesModelEditor.java:181
-msgid "Explicit carbons"
+msgid "All Carbons Explicit"
 msgstr "Explizite Kohlenstoffe"
 
 #: src/main/org/openscience/jchempaint/dialog/editor/PropertiesModelEditor.java:185
-msgid "Show explicit methyl groups"
+msgid "Terminal Carbons Explicit"
 msgstr "Explizite Methylgruppen zeichnen"
 
 #: src/main/org/openscience/jchempaint/dialog/editor/PropertiesModelEditor.java:189
@@ -547,15 +547,15 @@ msgid "Atom size"
 msgstr "Atomgröße"
 
 #: src/main/org/openscience/jchempaint/dialog/editor/PropertiesModelEditor.java:261
-msgid "Bond width"
+msgid "Bond Width"
 msgstr "Bindungsweite"
 
 #: src/main/org/openscience/jchempaint/dialog/editor/PropertiesModelEditor.java:280
-msgid "Highlight/Select diameter"
+msgid "Highlight Distance"
 msgstr "Radius zum Auswählen"
 
 #: src/main/org/openscience/jchempaint/dialog/editor/PropertiesModelEditor.java:290
-msgid "Wedge width"
+msgid "Wedge Width"
 msgstr "Keilbreite"
 
 #: src/main/org/openscience/jchempaint/dialog/editor/PropertiesModelEditor.java:305

--- a/core/po/es.po
+++ b/core/po/es.po
@@ -469,11 +469,11 @@ msgid "Draw atom numbers"
 msgstr "Dibujar números de los átomos"
 
 #: src/main/org/openscience/jchempaint/dialog/editor/PropertiesModelEditor.java:181
-msgid "Explicit carbons"
+msgid "All Carbons Explicit"
 msgstr "Carbonos explícitos"
 
 #: src/main/org/openscience/jchempaint/dialog/editor/PropertiesModelEditor.java:185
-msgid "Show explicit methyl groups"
+msgid "Terminal Carbons Explicit"
 msgstr "Mostrar los grupos metilo explícitos"
 
 #: src/main/org/openscience/jchempaint/dialog/editor/PropertiesModelEditor.java:189
@@ -517,15 +517,15 @@ msgid "Atom size"
 msgstr "Tamaño de átomo"
 
 #: src/main/org/openscience/jchempaint/dialog/editor/PropertiesModelEditor.java:261
-msgid "Bond width"
+msgid "Bond Width"
 msgstr "Grosor de enlaces"
 
 #: src/main/org/openscience/jchempaint/dialog/editor/PropertiesModelEditor.java:280
-msgid "Highlight/Select diameter"
+msgid "Highlight Distance"
 msgstr "Diámetro de resaltado o seleccionado"
 
 #: src/main/org/openscience/jchempaint/dialog/editor/PropertiesModelEditor.java:290
-msgid "Wedge width"
+msgid "Wedge Width"
 msgstr "Anchura de las cuñas"
 
 #: src/main/org/openscience/jchempaint/dialog/editor/PropertiesModelEditor.java:305

--- a/core/po/hu.po
+++ b/core/po/hu.po
@@ -518,11 +518,11 @@ msgid "Draw atom numbers"
 msgstr "Atomszámok rajzolása"
 
 #: src/main/org/openscience/jchempaint/dialog/editor/PropertiesModelEditor.java:181
-msgid "Explicit carbons"
+msgid "All Carbons Explicit"
 msgstr "Az összes szénatom megjelenítése"
 
 #: src/main/org/openscience/jchempaint/dialog/editor/PropertiesModelEditor.java:185
-msgid "Show explicit methyl groups"
+msgid "Terminal Carbons Explicit"
 msgstr "Az összes metilcsoport megjelenítése"
 
 #: src/main/org/openscience/jchempaint/dialog/editor/PropertiesModelEditor.java:189
@@ -566,15 +566,15 @@ msgid "Atom size"
 msgstr "Atomméret"
 
 #: src/main/org/openscience/jchempaint/dialog/editor/PropertiesModelEditor.java:261
-msgid "Bond width"
+msgid "Bond Width"
 msgstr "Kötés szélessége"
 
 #: src/main/org/openscience/jchempaint/dialog/editor/PropertiesModelEditor.java:280
-msgid "Highlight/Select diameter"
+msgid "Highlight Distance"
 msgstr "Átmérő kiválasztása/megjelenítése"
 
 #: src/main/org/openscience/jchempaint/dialog/editor/PropertiesModelEditor.java:290
-msgid "Wedge width"
+msgid "Wedge Width"
 msgstr "Ék szélessége"
 
 #: src/main/org/openscience/jchempaint/dialog/editor/PropertiesModelEditor.java:305
@@ -2812,7 +2812,7 @@ msgstr "Visszavonás nem lehetséges"
 #~ msgid "Font name"
 #~ msgstr "Betűkészlet neve"
 
-#~ msgid "Choose Color..."
+#~ msgid "Choose"
 #~ msgstr "Szín választás...."
 
 #~ msgid "Oval Compact Atoms"

--- a/core/po/keys.pot
+++ b/core/po/keys.pot
@@ -483,11 +483,11 @@ msgid "Draw atom numbers"
 msgstr ""
 
 #: src/main/org/openscience/jchempaint/dialog/editor/PropertiesModelEditor.java:181
-msgid "Explicit carbons"
+msgid "All Carbons Explicit"
 msgstr ""
 
 #: src/main/org/openscience/jchempaint/dialog/editor/PropertiesModelEditor.java:185
-msgid "Show explicit methyl groups"
+msgid "Terminal Carbons Explicit"
 msgstr ""
 
 #: src/main/org/openscience/jchempaint/dialog/editor/PropertiesModelEditor.java:189
@@ -531,15 +531,15 @@ msgid "Atom size"
 msgstr ""
 
 #: src/main/org/openscience/jchempaint/dialog/editor/PropertiesModelEditor.java:261
-msgid "Bond width"
+msgid "Bond Width"
 msgstr ""
 
 #: src/main/org/openscience/jchempaint/dialog/editor/PropertiesModelEditor.java:280
-msgid "Highlight/Select diameter"
+msgid "Highlight Distance"
 msgstr ""
 
 #: src/main/org/openscience/jchempaint/dialog/editor/PropertiesModelEditor.java:290
-msgid "Wedge width"
+msgid "Wedge Width"
 msgstr ""
 
 #: src/main/org/openscience/jchempaint/dialog/editor/PropertiesModelEditor.java:305

--- a/core/po/nl.po
+++ b/core/po/nl.po
@@ -504,11 +504,11 @@ msgid "Draw atom numbers"
 msgstr "Teken atoomnummers"
 
 #: src/main/org/openscience/jchempaint/dialog/editor/PropertiesModelEditor.java:181
-msgid "Explicit carbons"
+msgid "All Carbons Explicit"
 msgstr "Explicitiete waterstofatomen"
 
 #: src/main/org/openscience/jchempaint/dialog/editor/PropertiesModelEditor.java:185
-msgid "Show explicit methyl groups"
+msgid "Terminal Carbons Explicit"
 msgstr "Laat methylgroupen expliciet zien"
 
 #: src/main/org/openscience/jchempaint/dialog/editor/PropertiesModelEditor.java:189
@@ -555,16 +555,16 @@ msgid "Atom size"
 msgstr "Atoomgrootte"
 
 #: src/main/org/openscience/jchempaint/dialog/editor/PropertiesModelEditor.java:261
-msgid "Bond width"
+msgid "Bond Width"
 msgstr "Bondbreedte"
 
 #: src/main/org/openscience/jchempaint/dialog/editor/PropertiesModelEditor.java:280
 #, fuzzy
-msgid "Highlight/Select diameter"
+msgid "Highlight Distance"
 msgstr "Straal oplichten"
 
 #: src/main/org/openscience/jchempaint/dialog/editor/PropertiesModelEditor.java:290
-msgid "Wedge width"
+msgid "Wedge Width"
 msgstr "Breedte wedge-bindingen"
 
 #: src/main/org/openscience/jchempaint/dialog/editor/PropertiesModelEditor.java:305
@@ -2826,7 +2826,7 @@ msgstr "Ongedaan maken niet mogelijk"
 #~ msgid "Font name"
 #~ msgstr "Lettertype"
 
-#~ msgid "Choose Color..."
+#~ msgid "Choose"
 #~ msgstr "Kies kleur..."
 
 #~ msgid "Choose a Font"

--- a/core/po/pl.po
+++ b/core/po/pl.po
@@ -512,11 +512,11 @@ msgid "Draw atom numbers"
 msgstr "Dorysuj numery atomów"
 
 #: src/main/org/openscience/jchempaint/dialog/editor/PropertiesModelEditor.java:181
-msgid "Explicit carbons"
+msgid "All Carbons Explicit"
 msgstr "Jawne atomy węgla"
 
 #: src/main/org/openscience/jchempaint/dialog/editor/PropertiesModelEditor.java:185
-msgid "Show explicit methyl groups"
+msgid "Terminal Carbons Explicit"
 msgstr "Pokaż jawne grupy metylowe"
 
 #: src/main/org/openscience/jchempaint/dialog/editor/PropertiesModelEditor.java:189
@@ -561,15 +561,15 @@ msgid "Atom size"
 msgstr "Rozmiar atomu"
 
 #: src/main/org/openscience/jchempaint/dialog/editor/PropertiesModelEditor.java:261
-msgid "Bond width"
+msgid "Bond Width"
 msgstr "Szerokość wiązania"
 
 #: src/main/org/openscience/jchempaint/dialog/editor/PropertiesModelEditor.java:280
-msgid "Highlight/Select diameter"
+msgid "Highlight Distance"
 msgstr "Podświetl/Wybierz średnicę"
 
 #: src/main/org/openscience/jchempaint/dialog/editor/PropertiesModelEditor.java:290
-msgid "Wedge width"
+msgid "Wedge Width"
 msgstr "Szerokość klina"
 
 #: src/main/org/openscience/jchempaint/dialog/editor/PropertiesModelEditor.java:305

--- a/core/po/pt_BR.po
+++ b/core/po/pt_BR.po
@@ -514,11 +514,11 @@ msgid "Draw atom numbers"
 msgstr "Desenhar número dos átomos"
 
 #: src/main/org/openscience/jchempaint/dialog/editor/PropertiesModelEditor.java:181
-msgid "Explicit carbons"
+msgid "All Carbons Explicit"
 msgstr "Carbonos explícitos"
 
 #: src/main/org/openscience/jchempaint/dialog/editor/PropertiesModelEditor.java:185
-msgid "Show explicit methyl groups"
+msgid "Terminal Carbons Explicit"
 msgstr "Mostrar grupos metila explicitamente"
 
 #: src/main/org/openscience/jchempaint/dialog/editor/PropertiesModelEditor.java:189
@@ -562,15 +562,15 @@ msgid "Atom size"
 msgstr "Tamanho do átomo"
 
 #: src/main/org/openscience/jchempaint/dialog/editor/PropertiesModelEditor.java:261
-msgid "Bond width"
+msgid "Bond Width"
 msgstr "Largura da ligação"
 
 #: src/main/org/openscience/jchempaint/dialog/editor/PropertiesModelEditor.java:280
-msgid "Highlight/Select diameter"
+msgid "Highlight Distance"
 msgstr "Destacar/Selecionar diâmetro"
 
 #: src/main/org/openscience/jchempaint/dialog/editor/PropertiesModelEditor.java:290
-msgid "Wedge width"
+msgid "Wedge Width"
 msgstr "Largura da borda"
 
 #: src/main/org/openscience/jchempaint/dialog/editor/PropertiesModelEditor.java:305
@@ -2781,7 +2781,7 @@ msgstr "Impossível desfazer"
 #~ msgid "Font name"
 #~ msgstr "Nome da fonte"
 
-#~ msgid "Choose Color..."
+#~ msgid "Choose"
 #~ msgstr "Escolher Cor..."
 
 #~ msgid "Choose a Font"

--- a/core/po/ru.po
+++ b/core/po/ru.po
@@ -491,11 +491,11 @@ msgid "Draw atom numbers"
 msgstr "Номера атомов"
 
 #: src/main/org/openscience/jchempaint/dialog/editor/PropertiesModelEditor.java:181
-msgid "Explicit carbons"
+msgid "All Carbons Explicit"
 msgstr "Символы атомов углерода"
 
 #: src/main/org/openscience/jchempaint/dialog/editor/PropertiesModelEditor.java:185
-msgid "Show explicit methyl groups"
+msgid "Terminal Carbons Explicit"
 msgstr "Символы метильных групп"
 
 #: src/main/org/openscience/jchempaint/dialog/editor/PropertiesModelEditor.java:189
@@ -539,15 +539,15 @@ msgid "Atom size"
 msgstr "Размер атома"
 
 #: src/main/org/openscience/jchempaint/dialog/editor/PropertiesModelEditor.java:261
-msgid "Bond width"
+msgid "Bond Width"
 msgstr "Толщина связи"
 
 #: src/main/org/openscience/jchempaint/dialog/editor/PropertiesModelEditor.java:280
-msgid "Highlight/Select diameter"
+msgid "Highlight Distance"
 msgstr "Диаметр выделения"
 
 #: src/main/org/openscience/jchempaint/dialog/editor/PropertiesModelEditor.java:290
-msgid "Wedge width"
+msgid "Wedge Width"
 msgstr "Ширина клиновидной связи"
 
 #: src/main/org/openscience/jchempaint/dialog/editor/PropertiesModelEditor.java:305

--- a/core/po/th.po
+++ b/core/po/th.po
@@ -507,11 +507,11 @@ msgid "Draw atom numbers"
 msgstr "วาดเลขอะตอม"
 
 #: src/main/org/openscience/jchempaint/dialog/editor/PropertiesModelEditor.java:181
-msgid "Explicit carbons"
+msgid "All Carbons Explicit"
 msgstr "คาร์บอนแบบแยกกัน"
 
 #: src/main/org/openscience/jchempaint/dialog/editor/PropertiesModelEditor.java:185
-msgid "Show explicit methyl groups"
+msgid "Terminal Carbons Explicit"
 msgstr "แสดงหมู่เมธิลแบบแยกกัน"
 
 #: src/main/org/openscience/jchempaint/dialog/editor/PropertiesModelEditor.java:189
@@ -555,15 +555,15 @@ msgid "Atom size"
 msgstr "ขนาดอะตอม"
 
 #: src/main/org/openscience/jchempaint/dialog/editor/PropertiesModelEditor.java:261
-msgid "Bond width"
+msgid "Bond Width"
 msgstr "ความกว้างพันธะ"
 
 #: src/main/org/openscience/jchempaint/dialog/editor/PropertiesModelEditor.java:280
-msgid "Highlight/Select diameter"
+msgid "Highlight Distance"
 msgstr "เฉดสี/เลือกเส้นผ่าศูนย์กลาง"
 
 #: src/main/org/openscience/jchempaint/dialog/editor/PropertiesModelEditor.java:290
-msgid "Wedge width"
+msgid "Wedge Width"
 msgstr "ความกว้างลิ่ม"
 
 #: src/main/org/openscience/jchempaint/dialog/editor/PropertiesModelEditor.java:305
@@ -2792,7 +2792,7 @@ msgstr "ไม่มีการเลิกทำ ที่เป็นไป�
 #~ msgid "Font name"
 #~ msgstr "ชื่อแบบอักษร"
 
-#~ msgid "Choose Color..."
+#~ msgid "Choose"
 #~ msgstr "เลือกสี..."
 
 #~ msgid "General Settings"

--- a/core/po/zh.po
+++ b/core/po/zh.po
@@ -483,11 +483,11 @@ msgid "Draw atom numbers"
 msgstr "画原子数"
 
 #: src/main/org/openscience/jchempaint/dialog/editor/PropertiesModelEditor.java:181
-msgid "Explicit carbons"
+msgid "All Carbons Explicit"
 msgstr "显示碳"
 
 #: src/main/org/openscience/jchempaint/dialog/editor/PropertiesModelEditor.java:185
-msgid "Show explicit methyl groups"
+msgid "Terminal Carbons Explicit"
 msgstr "显示甲基"
 
 #: src/main/org/openscience/jchempaint/dialog/editor/PropertiesModelEditor.java:189
@@ -532,15 +532,15 @@ msgid "Atom size"
 msgstr "原子大小"
 
 #: src/main/org/openscience/jchempaint/dialog/editor/PropertiesModelEditor.java:261
-msgid "Bond width"
+msgid "Bond Width"
 msgstr "键宽"
 
 #: src/main/org/openscience/jchempaint/dialog/editor/PropertiesModelEditor.java:280
-msgid "Highlight/Select diameter"
+msgid "Highlight Distance"
 msgstr "增强/选择 半径"
 
 #: src/main/org/openscience/jchempaint/dialog/editor/PropertiesModelEditor.java:290
-msgid "Wedge width"
+msgid "Wedge Width"
 msgstr "楔宽度"
 
 #: src/main/org/openscience/jchempaint/dialog/editor/PropertiesModelEditor.java:305

--- a/core/src/main/java/org/openscience/jchempaint/JCPPropertyHandler.java
+++ b/core/src/main/java/org/openscience/jchempaint/JCPPropertyHandler.java
@@ -362,6 +362,10 @@ public class JCPPropertyHandler
                                                                  .getJCPProperties().getProperty("BackColor", String.valueOf(Color.white.getRGB())))));
         model.setBondWidth(Double.parseDouble(JCPPropertyHandler.getInstance(useUserSettings)
                                                                 .getJCPProperties().getProperty("BondWidth")));
+        model.setWedgeWidth(Double.parseDouble(JCPPropertyHandler.getInstance(useUserSettings)
+                                                                .getJCPProperties().getProperty("WedgeWidth")));
+        model.setHashSpacing(Double.parseDouble(JCPPropertyHandler.getInstance(useUserSettings)
+                                                                .getJCPProperties().getProperty("HashSpacing")));
         model.setCompactShape(JCPPropertyHandler.getInstance(useUserSettings).getJCPProperties()
                                          .getProperty("CompactShape").equals("square") ? BasicAtomGenerator.Shape.SQUARE : BasicAtomGenerator.Shape.OVAL);
         model.setIsCompact(Boolean.parseBoolean(JCPPropertyHandler.getInstance(useUserSettings)
@@ -387,6 +391,7 @@ public class JCPPropertyHandler
         model.setWedgeWidth(Double.parseDouble(JCPPropertyHandler.getInstance(useUserSettings)
                                                           .getJCPProperties().getProperty("WedgeWidth")));
         model.setShowReactionBoxes(Boolean.parseBoolean(JCPPropertyHandler.getInstance(useUserSettings)
-                                                                   .getJCPProperties().getProperty("ShowReactionBoxes")));    
+                                                                   .getJCPProperties().getProperty("ShowReactionBoxes")));
+
     }
 }

--- a/core/src/main/java/org/openscience/jchempaint/JCPPropertyHandler.java
+++ b/core/src/main/java/org/openscience/jchempaint/JCPPropertyHandler.java
@@ -364,6 +364,8 @@ public class JCPPropertyHandler
                                                                 .getJCPProperties().getProperty("BondWidth")));
         model.setWedgeWidth(Double.parseDouble(JCPPropertyHandler.getInstance(useUserSettings)
                                                                 .getJCPProperties().getProperty("WedgeWidth")));
+        model.setBondSeparation(Double.parseDouble(JCPPropertyHandler.getInstance(useUserSettings)
+                                                                  .getJCPProperties().getProperty("BondSpacing")));
         model.setHashSpacing(Double.parseDouble(JCPPropertyHandler.getInstance(useUserSettings)
                                                                 .getJCPProperties().getProperty("HashSpacing")));
         model.setCompactShape(JCPPropertyHandler.getInstance(useUserSettings).getJCPProperties()

--- a/core/src/main/java/org/openscience/jchempaint/JChemPaintPanel.java
+++ b/core/src/main/java/org/openscience/jchempaint/JChemPaintPanel.java
@@ -406,10 +406,10 @@ public class JChemPaintPanel extends AbstractJChemPaintPanel implements
                     case '7': relay.addRing(hgBond, 7, false); break;
                     case '8': relay.addRing(hgBond, 8, false); break;
                     case 'a': relay.addPhenyl(hgBond, false); break;
-                    case 'w': relay.changeBond(hgBond, IBond.Order.SINGLE, IBond.Stereo.UP); break;
+                    case 'w': relay.changeBond(hgBond, IBond.Order.SINGLE, IBond.Stereo.UP, IBond.Display.WedgeBegin); break;
                     case 'W': // shift + W
-                    case 'h': relay.changeBond(hgBond, IBond.Order.SINGLE, IBond.Stereo.DOWN); break;
-                    case 'y': relay.changeBond(hgBond, IBond.Order.SINGLE, IBond.Stereo.UP_OR_DOWN); break;
+                    case 'h': relay.changeBond(hgBond, IBond.Order.SINGLE, IBond.Stereo.DOWN, IBond.Display.WedgedHashBegin); break;
+                    case 'y': relay.changeBond(hgBond, IBond.Order.SINGLE, IBond.Stereo.UP_OR_DOWN, IBond.Display.Wavy); break;
                     case 'b': relay.changeBond(hgBond, IBond.Order.SINGLE, IBond.Stereo.NONE, IBond.Display.Bold); break;
                     default: changed = false;
                 }

--- a/core/src/main/java/org/openscience/jchempaint/action/CopyPasteAction.java
+++ b/core/src/main/java/org/openscience/jchempaint/action/CopyPasteAction.java
@@ -55,6 +55,8 @@ import org.openscience.cdk.io.ReaderFactory;
 import org.openscience.cdk.isomorphism.matchers.IRGroupQuery;
 import org.openscience.cdk.isomorphism.matchers.RGroupQuery;
 import org.openscience.cdk.layout.StructureDiagramGenerator;
+import org.openscience.cdk.renderer.RendererModel;
+import org.openscience.cdk.renderer.generators.BasicSceneGenerator;
 import org.openscience.cdk.renderer.selection.IChemObjectSelection;
 import org.openscience.cdk.smiles.SmilesGenerator;
 import org.openscience.cdk.smiles.SmilesParser;
@@ -160,7 +162,8 @@ public final class CopyPasteAction extends JCPAction {
                     || !container.contains(bond.getAtom(1)))
                     container.removeBond(bond);
             if (container.getAtomCount() > 0) {
-                JcpSelection jcpselection = new JcpSelection(container.clone());
+                JcpSelection jcpselection = new JcpSelection(container.clone(),
+                                                             jcpPanel.getRenderPanel().getRendererModel());
                 clipboard.setContents(jcpselection, null);
             }
         } catch (CloneNotSupportedException ex) {
@@ -673,7 +676,7 @@ public final class CopyPasteAction extends JCPAction {
         String cml;
         File file;
 
-        public JcpSelection(IAtomContainer container) {
+        public JcpSelection(IAtomContainer container, RendererModel model) {
             IAtomContainer tocopy = container.getBuilder()
                                              .newInstance(IAtomContainer.class,
                                                           container);
@@ -696,7 +699,10 @@ public final class CopyPasteAction extends JCPAction {
 
             Depiction depiction = null;
             try {
-                depiction = new DepictionGenerator().depict(container);
+                depiction = new DepictionGenerator().withParams(model)
+                                                    .withParam(BasicSceneGenerator.Margin.class,
+                                                               DepictionGenerator.AUTOMATIC)
+                                                    .depict(container);
                 image = depiction.toImg();
                 pdf = depiction.toPdf();
                 svg = depiction.toSvgStr();

--- a/core/src/main/java/org/openscience/jchempaint/application/JChemPaint.java
+++ b/core/src/main/java/org/openscience/jchempaint/application/JChemPaint.java
@@ -179,7 +179,8 @@ public class JChemPaint {
             }
 
             // Language
-            props.setProperty("General.language", System.getProperty("user.language", "en"));
+            props.setProperty("General.language",
+                              System.getProperty("user.language", "en"));
 
             // Process command line arguments
             String modelFilename = "";

--- a/core/src/main/java/org/openscience/jchempaint/controller/ControllerHub.java
+++ b/core/src/main/java/org/openscience/jchempaint/controller/ControllerHub.java
@@ -1419,6 +1419,8 @@ public class ControllerHub implements IMouseEventRelay, IChemModelRelay {
 				(stereo == Stereo.UP || stereo == Stereo.DOWN)) {
 				stereoChanges.put(bond, new Stereo[]{stereo == Stereo.UP ? Stereo.UP_INVERTED : Stereo.DOWN_INVERTED,
 													 bond.getStereo()});
+                displayChanges.put(bond, new Display[]{stereo == Stereo.UP ? Display.WedgeEnd : Display.WedgedHashEnd,
+                                                       bond.getDisplay()});
 			} else {
 				if (bond.getOrder() != order)
 					orderChanges.put(bond, new Order[]{order, bond.getOrder()});
@@ -1437,8 +1439,6 @@ public class ControllerHub implements IMouseEventRelay, IChemModelRelay {
                             flipped = true;
                     }
 
-                    System.err.println(flipped);
-
                     switch (stereo) {
                         case UP:
                             stereoChanges.put(bond, new Stereo[]{flipped ? Stereo.UP_INVERTED : Stereo.UP, bond.getStereo()});
@@ -1451,7 +1451,8 @@ public class ControllerHub implements IMouseEventRelay, IChemModelRelay {
                             break;
                     }
                 }
-                else if (bond.getDisplay() != disp) {
+
+                if (bond.getDisplay() != disp && disp != null) {
                     displayChanges.put(bond, new Display[]{disp, bond.getDisplay()});
                 }
 			}

--- a/core/src/main/java/org/openscience/jchempaint/dialog/FieldTablePanel.java
+++ b/core/src/main/java/org/openscience/jchempaint/dialog/FieldTablePanel.java
@@ -44,69 +44,73 @@ import javax.swing.JTabbedPane;
 /**
  * Swing class that allows easy building of edit forms.
  *
- * @cdk.svnrev  $Revision: 11740 $
+ * @cdk.svnrev $Revision: 11740 $
  */
 public class FieldTablePanel extends JPanel {
-        
-	private static final long serialVersionUID = -697566299504877020L;
 
-	protected static final int DEF_INSET=10;
+    private static final long serialVersionUID = -697566299504877020L;
 
-	protected int rows;
+    protected static final int DEF_INSET = 10;
+
+    protected int rows;
 
     protected JTabbedPane tabbedPane;
-    
+
     /**
      * Constructor for field table panel.
-     * 
+     *
      * @param hasTabs True=tabs are added, false=fields go directly on here.
      */
     public FieldTablePanel(boolean hasTabs) {
-        if(hasTabs){
+        if (hasTabs) {
             setLayout(new BorderLayout());
             tabbedPane = new JTabbedPane();
             tabbedPane.setName("tabs");
-            add( tabbedPane, BorderLayout.CENTER );
-        }else{
+            add(tabbedPane, BorderLayout.CENTER);
+        } else {
             setLayout(new GridBagLayout());
         }
         rows = 0;
     }
-    
+
     /**
      * Adds a tab.
-     * 
+     *
      * @param header The header for the tab.
      * @return A JPanel, which you will need later to add fields.
      */
-    public JPanel addTab(String header){
+    public JPanel addTab(String header) {
         JPanel panel = new JPanel();
         panel.setLayout(new GridBagLayout());
-        tabbedPane.addTab(header, panel );
+        tabbedPane.addTab(header, panel);
         return panel;
     }
-    
+
     /**
      * Adds a new JComponent to the 2 column table layout. Both
      * elements will be layed out in the same row. For larger
      * <code>JComponent</code>s the addArea() can be used.
-     * 
+     *
      * @param labelText The text in left column.
      * @param component The control to add.
      * @param panel     The panel to add to. This must be either a panel you got from addTab or null if in no tab mode.
-     * @param inset     Spacing distance between objects on the panel 
+     * @param inset     Spacing distance between objects on the panel
      */
     public void addField(String labelText, JComponent component, JPanel panel, int inset) {
-        if(panel==null)
-            panel=this;
+        if (panel == null)
+            panel = this;
         rows++;
-        GridBagConstraints constraints = new GridBagConstraints();
-        constraints.insets = new Insets(inset,inset,inset,inset);
         JLabel label = new JLabel("", JLabel.TRAILING);
-        if (labelText != null && labelText.length() > 0) {
+        if (labelText != null && !labelText.isEmpty()) {
             label = new JLabel(labelText + ": ", JLabel.TRAILING);
         }
         label.setLabelFor(component);
+        addField(label, component, panel, inset);
+    }
+
+    public void addField(JLabel label, JComponent component, JPanel panel, int inset) {
+        GridBagConstraints constraints = new GridBagConstraints();
+        constraints.insets = new Insets(inset, inset, inset, inset);
         constraints.gridx = 0;
         constraints.gridy = rows;
         constraints.fill = GridBagConstraints.HORIZONTAL;
@@ -117,12 +121,12 @@ public class FieldTablePanel extends JPanel {
         constraints.fill = GridBagConstraints.HORIZONTAL;
         panel.add(component, constraints);
     }
-    
+
     public void addField(String labelText, JComponent component, JPanel panel) {
-    	addField(labelText, component, panel, 0);
+        addField(labelText, component, panel, 0);
     }
 
-    
+
     /**
      * Adds a new JComponent to the 2 column table layout. The JLabel
      * will be placed in one row, while the <code>JComponent</code>
@@ -150,7 +154,7 @@ public class FieldTablePanel extends JPanel {
         editorScrollPane.setMinimumSize(new Dimension(10, 10));
         add(editorScrollPane, constraints);
     }
-    
+
 }
 
 

--- a/core/src/main/java/org/openscience/jchempaint/dialog/editor/PropertiesModelEditor.java
+++ b/core/src/main/java/org/openscience/jchempaint/dialog/editor/PropertiesModelEditor.java
@@ -31,12 +31,14 @@ package org.openscience.jchempaint.dialog.editor;
 
 import java.awt.Color;
 import java.awt.Container;
+import java.awt.GridBagLayout;
+import java.awt.GridLayout;
+import java.awt.Toolkit;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.util.Properties;
 
 import javax.swing.BoxLayout;
-import javax.swing.ButtonGroup;
 import javax.swing.JButton;
 import javax.swing.JCheckBox;
 import javax.swing.JColorChooser;
@@ -46,15 +48,15 @@ import javax.swing.JFrame;
 import javax.swing.JLabel;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
-import javax.swing.JRadioButton;
 import javax.swing.JSeparator;
 import javax.swing.JSlider;
+import javax.swing.JSpinner;
 import javax.swing.JTextField;
+import javax.swing.SpinnerNumberModel;
 import javax.swing.SwingUtilities;
 import javax.swing.UIManager;
 import javax.swing.UnsupportedLookAndFeelException;
 
-import org.openscience.cdk.renderer.generators.BasicAtomGenerator;
 import org.openscience.jchempaint.AbstractJChemPaintPanel;
 import org.openscience.jchempaint.GT;
 import org.openscience.jchempaint.JCPPropertyHandler;
@@ -65,7 +67,7 @@ import org.openscience.jchempaint.dialog.ModifyRenderOptionsDialog;
 import org.openscience.jchempaint.renderer.JChemPaintRendererModel;
 
 /**
- * @cdk.bug          1525961
+ * @cdk.bug 1525961
  */
 public class PropertiesModelEditor extends FieldTablePanel implements ActionListener {
 
@@ -77,13 +79,13 @@ public class PropertiesModelEditor extends FieldTablePanel implements ActionList
 
     //private JCheckBox showAtomAtomMapping;
 
-    private JCheckBox useKekuleStructure;
+    private JCheckBox showAllCarbons;
 
     private JCheckBox showEndCarbons;
 
-    private JCheckBox showExplicitHydrogens;
-
-    private JCheckBox showImplicitHydrogens;
+//    private JCheckBox showExplicitHydrogens;
+//
+//    private JCheckBox showImplicitHydrogens;
 
     private JCheckBox showAromaticity;
 
@@ -99,23 +101,17 @@ public class PropertiesModelEditor extends FieldTablePanel implements ActionList
 
     private JCheckBox isFitToScreen;
 
-    private JSlider bondWidth;
+    private JSpinner strokeWidth;
+
+    private JSpinner bondSeparation;
 
     //private JSlider bondLength;
 
-    private JSlider highlightDistance;
+    private JSpinner highlightDistance;
 
-    private JSlider atomRadius;
+    private JSpinner wedgeWidth;
 
-    private JSlider wedgeWidth;
-
-    private ButtonGroup group = new ButtonGroup();
-
-    private JRadioButton nonCompactShape;
-
-    private JRadioButton compactShapeOval;
-
-    private JRadioButton compactShapeSquare;
+    private JSpinner hashSpacing;
 
     //private JLabel fontName;
 
@@ -164,7 +160,7 @@ public class PropertiesModelEditor extends FieldTablePanel implements ActionList
         options1.setLayout(new BoxLayout(options1, BoxLayout.PAGE_AXIS));
         rendererOptionsPanel.add(options1);
         JPanel options2 = new JPanel();
-        options2.setLayout(new BoxLayout(options2, BoxLayout.PAGE_AXIS));
+        options2.setLayout(new GridBagLayout());
         rendererOptionsPanel.add(options2);
 
         //addField("",new JPanel());
@@ -172,29 +168,23 @@ public class PropertiesModelEditor extends FieldTablePanel implements ActionList
         addField("", new JLabel(" "), options1);
 
         drawNumbers = new JCheckBox(GT.get("Draw atom numbers"));
+        drawNumbers.setEnabled(false);
         options1.add(drawNumbers);
         //addField(GT._("Draw atom numbers"), drawNumbers, options1);
 
         //showAtomAtomMapping = new JCheckBox();
         //addField(GT._("Show atom-atom mappings"), showAtomAtomMapping);
 
-        useKekuleStructure = new JCheckBox(GT.get("Explicit carbons"));
-        options1.add(useKekuleStructure);
+        showAllCarbons = new JCheckBox(GT.get("All Carbons Explicit"));
+        options1.add(showAllCarbons);
         //addField(GT._("Explicit carbons"), useKekuleStructure, options1);
 
-        showEndCarbons = new JCheckBox(GT.get("Show explicit methyl groups"));
+        showEndCarbons = new JCheckBox(GT.get("Terminal Carbons Explicit"));
         options1.add(showEndCarbons);
         //addField(GT._("Show explicit methyl groups"), showEndCarbons, options1);
 
-        showExplicitHydrogens = new JCheckBox(GT.get("Show explicit hydrogens"));
-        options1.add(showExplicitHydrogens);
-        //addField(GT._("Show explicit hydrogens"), showExplicitHydrogens, options1);
-
-        showImplicitHydrogens = new JCheckBox(GT.get("Show implicit hydrogens"));
-        options1.add(showImplicitHydrogens);
-        //addField(GT._("Show implicit hydrogens"), showImplicitHydrogens, options1);
-
         showAromaticity = new JCheckBox(GT.get("Show aromatic ring circles"));
+        showAromaticity.setEnabled(false);
         options1.add(showAromaticity);
         //addField(GT._("Show aromatic ring circles"), showAromaticity, options1);
 
@@ -216,80 +206,32 @@ public class PropertiesModelEditor extends FieldTablePanel implements ActionList
 
 
         isFitToScreen = new JCheckBox(GT.get("Set fit to screen"));
-		options1.add(isFitToScreen);
+        options1.add(isFitToScreen);
         //addField(GT._("Set fit to screen"), isFitToScreen, options1);
 
-        addField("", new JLabel(" "), options1);
-        addField("", new JSeparator(), options1);
-		addField("", new JLabel(" "), options1);
+        color = new JLabel();
+        color.setText("      " + GT.get("Background Color") + "      ");
+        color.setOpaque(true);
+        options1.add(color);
 
-        nonCompactShape = new JRadioButton(GT.get("Show atom symbols"));
-        group.add(nonCompactShape);
-		options1.add(nonCompactShape);
-        //addField(GT._("Show atom symbols"), nonCompactShape, options1);
+        chooseColorButton = new JButton(GT.get("Choose"));
+        chooseColorButton.addActionListener(this);
+        chooseColorButton.setActionCommand("chooseColor");
+        addField(color, chooseColorButton, options2, 0);
 
-        compactShapeOval = new JRadioButton(GT.get("Show ball atoms"));
-        group.add(compactShapeOval);
-		options1.add(compactShapeOval);
-        //addField(GT._("Show ball atoms"), compactShapeOval, options1);
+        strokeWidth = new JSpinner(new SpinnerNumberModel(0, 0, 5, 0.1));
+        addField(GT.get("Bond Width"), strokeWidth, options2);
+        bondSeparation = new JSpinner(new SpinnerNumberModel(.18, 0, 1, .01));
+        JSpinner.NumberEditor editor = new JSpinner.NumberEditor(bondSeparation, "0%");
+        bondSeparation.setEditor(editor);
+        addField(GT.get("Bond Spacing (% of length)"), bondSeparation, options2);
+        wedgeWidth = new JSpinner(new SpinnerNumberModel(6.0, 0.0, 15.0, 1.0));
+        addField(GT.get("Wedge Width"), wedgeWidth, options2);
+        hashSpacing = new JSpinner(new SpinnerNumberModel(0, 0, 10, 0.1));
+        addField(GT.get("Hash Spacing"), hashSpacing, options2);
 
-        compactShapeSquare = new JRadioButton(GT.get("Show square atoms"));
-        group.add(compactShapeSquare);
-		options1.add(compactShapeSquare);
-        //addField(GT._("Show square atoms"), compactShapeSquare, options1);
-        addField("", new JLabel(" "), options1);
-		addField("", new JSeparator(), options1);
-
-        atomRadius = new JSlider(0, 20);
-        atomRadius.setSnapToTicks(true);
-        atomRadius.setPaintLabels(true);
-        atomRadius.setPaintTicks(true);
-        atomRadius.setMajorTickSpacing(5);
-        atomRadius.setMinorTickSpacing(1);
-		addField("", new JLabel(" "), options2);
-        addField(GT.get("Atom size"), atomRadius, options2);
-        addField("", new JLabel(" "), options2);
-        addField("", new JSeparator(), options2);
-
-
-        bondWidth = new JSlider(1, 5);
-        bondWidth.setSnapToTicks(true);
-        bondWidth.setPaintLabels(true);
-        bondWidth.setPaintTicks(true);
-        bondWidth.setMajorTickSpacing(1);
-		addField("", new JLabel(" "), options2);
-        addField(GT.get("Bond width"), bondWidth, options2);
-        addField("", new JLabel(" "), options2);
-        addField("", new JSeparator(), options2);
-
-        //bondLength = new JSlider(20, 60);
-        //bondLength.setSnapToTicks(true);
-        //bondLength.setPaintLabels(true);
-        //bondLength.setPaintTicks(true);
-        //bondLength.setMajorTickSpacing(5);
-        //bondLength.setMinorTickSpacing(1);
-        //addField(GT._("Bond length"), bondLength);
-
-        highlightDistance = new JSlider(0, 25);
-        highlightDistance.setSnapToTicks(true);
-        highlightDistance.setPaintLabels(true);
-        highlightDistance.setPaintTicks(true);
-        highlightDistance.setMajorTickSpacing(5);
-        highlightDistance.setMinorTickSpacing(1);
-		addField("", new JLabel(" "), options2);
-        addField(GT.get("Highlight/Select diameter"), highlightDistance, options2);
-        addField("", new JLabel(" "), options2);
-        addField("", new JSeparator(), options2);
-
-        wedgeWidth = new JSlider(1, 10);
-        wedgeWidth.setSnapToTicks(true);
-        wedgeWidth.setPaintLabels(true);
-        wedgeWidth.setPaintTicks(true);
-        wedgeWidth.setMajorTickSpacing(1);
-		addField("", new JLabel(" "), options2);
-        addField(GT.get("Wedge width"), wedgeWidth, options2);
-        addField("", new JLabel(" "), options2);
-        //addField("", new JSeparator(), options2);
+        highlightDistance = new JSpinner(new SpinnerNumberModel(5,0,25,1));
+        addField(GT.get("Highlight Distance"), highlightDistance, options2);
 
         /*
         currentFontName = "";
@@ -300,49 +242,35 @@ public class PropertiesModelEditor extends FieldTablePanel implements ActionList
         chooseFontButton.setActionCommand("chooseFont");
         addField("", chooseFontButton);
          */
-
-        color = new JLabel();
-		color.setText("      "+GT.get("Background color")+"      ");
-		color.setOpaque(true);
-		addField("", new JLabel(" "), options1);
-		options1.add(color);
-		addField("", new JLabel(" "), options1);
-        //addField(GT._("Background color"), color, options2);
-
-        chooseColorButton = new JButton(GT.get("Choose background color..."));
-        chooseColorButton.addActionListener(this);
-        chooseColorButton.setActionCommand("chooseColor");
-		options1.add(chooseColorButton);
-		addField("", new JLabel(" "), options1);
         //addField("", chooseColorButton, options2);
-		
+
         JPanel otherOptionsPanel = this.addTab(GT.get("Other Preferences"));
-        
+
         undoStackSize = new JTextField();
         addField(GT.get("Number of undoable operations"), undoStackSize, otherOptionsPanel);
 
         askForIOSettings = new JCheckBox();
         addField(GT.get("Ask for CML settings when saving"), askForIOSettings, otherOptionsPanel);
 
-		if (!guistring.equals(JChemPaintEditorApplet.GUI_APPLET)) {
-            String [] lookAndFeels = {GT.get("System"), "Metal", "Nimbus", "Motif", "GTK", "Windows"};
-		    lookAndFeel = new JComboBox<Object>(lookAndFeels);
-		    addField(GT.get("Look and feel"), lookAndFeel, otherOptionsPanel);
+        if (!guistring.equals(JChemPaintEditorApplet.GUI_APPLET)) {
+            String[] lookAndFeels = {GT.get("System"), "Metal", "Nimbus", "Motif", "GTK", "Windows"};
+            lookAndFeel = new JComboBox<Object>(lookAndFeels);
+            addField(GT.get("Look and feel"), lookAndFeel, otherOptionsPanel);
             addField("", new JSeparator(), otherOptionsPanel);
         }
 
         String[] languagesstrings = new String[gtlanguages.length];
-        for(int i=0;i<gtlanguages.length;i++){
+        for (int i = 0; i < gtlanguages.length; i++) {
             languagesstrings[i] = gtlanguages[i].language;
         }
         language = new JComboBox<Object>(languagesstrings);
         language.setName("language");
-        for(int i=0;i<languagesstrings.length;i++){
-            if(gtlanguages[i].code.equals(GT.getLanguage()))
+        for (int i = 0; i < languagesstrings.length; i++) {
+            if (gtlanguages[i].code.equals(GT.getLanguage()))
                 language.setSelectedIndex(i);
         }
         addField(GT.get("User Interface Language"), language, otherOptionsPanel);
-        
+
         this.tabbedPane.setSelectedIndex(tabtoshow);
     }
 
@@ -350,11 +278,9 @@ public class PropertiesModelEditor extends FieldTablePanel implements ActionList
         this.model = model;
         drawNumbers.setSelected(model.getDrawNumbers());
         //showAtomAtomMapping.setSelected(model.getShowAtomAtomMapping());
-        useKekuleStructure.setSelected(model.getKekuleStructure());
+        showAllCarbons.setSelected(model.getKekuleStructure());
         showEndCarbons.setSelected(model.getShowEndCarbons());
-        showExplicitHydrogens.setSelected(model.getShowExplicitHydrogens());
-        showImplicitHydrogens.setSelected(model.getShowImplicitHydrogens());
-        showAromaticity.setSelected(model.getShowAromaticity());
+        // showAromaticity.setSelected(false); // dissabled for now
         //showAromaticityCDKStyle.setSelected(model.getShowAromaticityCDKStyle());
         colorAtomsByType.setSelected(model.getColorAtomsByType());
         //useAntiAliasing.setSelected(model.getUseAntiAliasing());
@@ -362,19 +288,13 @@ public class PropertiesModelEditor extends FieldTablePanel implements ActionList
         showReactionBoxes.setSelected(model.getShowReactionBoxes());
         isFitToScreen.setSelected(model.isFitToScreen());
 
-        atomRadius.setValue((int)model.getAtomRadius());
-        bondWidth.setValue((int)model.getBondWidth());
+        strokeWidth.setValue(model.getBondWidth());
+        bondSeparation.setValue(model.getBondSeparation());
         //bondLength.setValue((int)model.getBondLength());
-        highlightDistance.setValue((int)model.getHighlightDistance());
-        wedgeWidth.setValue((int)model.getWedgeWidth());
+        highlightDistance.setValue((int) model.getHighlightDistance());
+        hashSpacing.setValue(model.getHashSpacing());
+        wedgeWidth.setValue(model.getWedgeWidth());
 
-        if (!model.getIsCompact()){
-            group.setSelected(nonCompactShape.getModel(), true);
-        } else if(model.getCompactShape() == BasicAtomGenerator.Shape.OVAL) {
-            group.setSelected(compactShapeOval.getModel(), true);
-        } else {
-            group.setSelected(compactShapeSquare.getModel(), true);
-        }
         /*
         currentFontName = model.getFontName();
         if (!currentFontName.equals("")) {
@@ -399,100 +319,96 @@ public class PropertiesModelEditor extends FieldTablePanel implements ActionList
 
     public void applyChanges(boolean close) {
         Properties props = JCPPropertyHandler.getInstance(true).getJCPProperties();
-        
+
         model.setDrawNumbers(drawNumbers.isSelected());
         //model.setShowAtomAtomMapping(showAtomAtomMapping.isSelected());
-        model.setKekuleStructure(useKekuleStructure.isSelected());
+        model.setKekuleStructure(showAllCarbons.isSelected());
         model.setShowEndCarbons(showEndCarbons.isSelected());
-        model.setShowExplicitHydrogens(showExplicitHydrogens.isSelected());
-        model.setShowImplicitHydrogens(showImplicitHydrogens.isSelected());
         model.setShowAromaticity(showAromaticity.isSelected());
         //model.setShowAromaticityCDKStyle(showAromaticityCDKStyle.isSelected());
         model.setColorAtomsByType(colorAtomsByType.isSelected());
         //model.setUseAntiAliasing(useAntiAliasing.isSelected());
         //model.setShowTooltip(showToolTip.isSelected());
         model.setShowReactionBoxes(showReactionBoxes.isSelected());
-        model.setIsCompact(!nonCompactShape.isSelected());
         model.setFitToScreen(isFitToScreen.isSelected());
 
-        model.setAtomRadius(atomRadius.getValue());
         //model.setBondLength(bondLength.getValue());
-        model.setBondWidth(bondWidth.getValue());
-        model.setHighlightDistance(highlightDistance.getValue());
-        model.setWedgeWidth(wedgeWidth.getValue());
-
-        if (compactShapeOval.isSelected()) {
-            model.setCompactShape(BasicAtomGenerator.Shape.OVAL);
-        } else {
-            model.setCompactShape(BasicAtomGenerator.Shape.SQUARE);
-        }
+        model.setBondWidth((double) strokeWidth.getValue());
+        model.setBondSeparation(((double)bondSeparation.getValue()));
+        model.setWedgeWidth((double) wedgeWidth.getValue());
+        model.setHashSpacing((double) hashSpacing.getValue());
+        model.setHighlightDistance((int)highlightDistance.getValue());
 
         model.setBackColor(currentColor);
-        
-        if(language.getSelectedIndex()!=-1) {
-        	GT.setLanguage(gtlanguages[language.getSelectedIndex()].code);
-        	jcpPanel.updateMenusWithLanguage();
-        	updateLanguge();
+
+        if (language.getSelectedIndex() != -1) {
+            GT.setLanguage(gtlanguages[language.getSelectedIndex()].code);
+            jcpPanel.updateMenusWithLanguage();
+            updateLanguge();
         }
 
-        props.setProperty("DrawNumbers",String.valueOf(drawNumbers.isSelected()));
+        props.setProperty("DrawNumbers", String.valueOf(drawNumbers.isSelected()));
         //props.setProperty("ShowAtomAtomMapping",String.valueOf(showAtomAtomMapping.isSelected()));
-        props.setProperty("KekuleStructure",String.valueOf(useKekuleStructure.isSelected()));
-        props.setProperty("ShowEndCarbons",String.valueOf(showEndCarbons.isSelected()));
-        props.setProperty("ShowExplicitHydrogens",String.valueOf(showExplicitHydrogens.isSelected()));
-        props.setProperty("ShowImplicitHydrogens",String.valueOf(showImplicitHydrogens.isSelected()));
-        props.setProperty("ShowAromaticity",String.valueOf(showAromaticity.isSelected()));
+        props.setProperty("KekuleStructure", String.valueOf(showAllCarbons.isSelected()));
+        props.setProperty("ShowEndCarbons", String.valueOf(showEndCarbons.isSelected()));
+        props.setProperty("ShowAromaticity", String.valueOf(showAromaticity.isSelected()));
         //props.setProperty("ShowAromaticityCDKStyle",String.valueOf(showAromaticityCDKStyle.isSelected()));
-        props.setProperty("ColorAtomsByType",String.valueOf(colorAtomsByType.isSelected()));
+        props.setProperty("ColorAtomsByType", String.valueOf(colorAtomsByType.isSelected()));
         //props.setProperty("UseAntiAliasing",String.valueOf(useAntiAliasing.isSelected()));
         //props.setProperty("ShowTooltip",String.valueOf(showToolTip.isSelected()));
-        props.setProperty("ShowReactionBoxes",String.valueOf(showReactionBoxes.isSelected()));
-        props.setProperty("IsCompact",String.valueOf(!nonCompactShape.isSelected()));
-        props.setProperty("FitToScreen",String.valueOf(isFitToScreen.isSelected()));
+        props.setProperty("ShowReactionBoxes", String.valueOf(showReactionBoxes.isSelected()));
+        props.setProperty("FitToScreen", String.valueOf(isFitToScreen.isSelected()));
 
-        props.setProperty("AtomRadius",String.valueOf(atomRadius.getValue()));
-        //props.setProperty("BondLength",String.valueOf(bondLength.getValue()));
-        props.setProperty("BondWidth",String.valueOf(bondWidth.getValue()));
-        props.setProperty("HighlightDistance",String.valueOf(highlightDistance.getValue()));
-        props.setProperty("WedgeWidth",String.valueOf(wedgeWidth.getValue()));
-
-        if (compactShapeOval.isSelected()) {
-            props.setProperty("CompactShape","oval");
-        } else {
-            props.setProperty("CompactShape","square");
-        }
+        props.setProperty("BondWidth", String.valueOf(strokeWidth.getValue()));
+        props.setProperty("BondSeparation", String.valueOf(bondSeparation.getValue()));
+        props.setProperty("HighlightDistance", String.valueOf(highlightDistance.getValue()));
+        props.setProperty("WedgeWidth", String.valueOf(wedgeWidth.getValue()));
+        props.setProperty("HashSpacing", String.valueOf(hashSpacing.getValue()));
 
         //props.setFontName(currentFontName);
-        props.setProperty("BackColor",String.valueOf(currentColor.getRGB()));
-                
+        props.setProperty("BackColor", String.valueOf(currentColor.getRGB()));
+
         //the general settings
         props.setProperty("General.askForIOSettings",
-            String.valueOf(askForIOSettings.isSelected())
-        );
+                          String.valueOf(askForIOSettings.isSelected())
+                         );
 
-        try{
-            int size=Integer.parseInt(undoStackSize.getText());
-            if(size<1 || size>100)
+        try {
+            int size = Integer.parseInt(undoStackSize.getText());
+            if (size < 1 || size > 100)
                 throw new Exception("wrong number");
             props.setProperty("General.UndoStackSize",
-                    undoStackSize.getText());
+                              undoStackSize.getText());
             jcpPanel.getRenderPanel().getUndoManager().setLimit(size);
-        }catch(Exception ex){
-            JOptionPane.showMessageDialog(this, GT.get("Number of undoable operations")+" "+GT.get("must be a number from 1 to 100"), GT.get("Number of undoable operations"), JOptionPane.WARNING_MESSAGE);
+        } catch (Exception ex) {
+            JOptionPane.showMessageDialog(this, GT.get("Number of undoable operations") + " " + GT.get("must be a number from 1 to 100"), GT.get("Number of undoable operations"), JOptionPane.WARNING_MESSAGE);
         }
         if (!guistring.equals(JChemPaintEditorApplet.GUI_APPLET)) {
-            String lnfName="";
-	    	try {
-		    	switch(lookAndFeel.getSelectedIndex()) {
-			    	case 0: lnfName = UIManager.getSystemLookAndFeelClassName(); break; // System
-				    case 1: lnfName = UIManager.getCrossPlatformLookAndFeelClassName(); break; // Metal
-                    case 2: lnfName = "com.sun.java.swing.plaf.nimbus.NimbusLookAndFeel"; break; // Nimbus
-	    			case 3: lnfName = "com.sun.java.swing.plaf.motif.MotifLookAndFeel"; break; // Motif
-		    		case 4: lnfName = "com.sun.java.swing.plaf.gtk.GTKLookAndFeel"; break; // GTK
-                    case 5: lnfName = "com.sun.java.swing.plaf.windows.WindowsLookAndFeel"; break; // Windows
-			        default: lnfName = "";
-		        }
-    			UIManager.setLookAndFeel(lnfName);
+            String lnfName = "";
+            try {
+                switch (lookAndFeel.getSelectedIndex()) {
+                    case 0:
+                        lnfName = UIManager.getSystemLookAndFeelClassName();
+                        break; // System
+                    case 1:
+                        lnfName = UIManager.getCrossPlatformLookAndFeelClassName();
+                        break; // Metal
+                    case 2:
+                        lnfName = "com.sun.java.swing.plaf.nimbus.NimbusLookAndFeel";
+                        break; // Nimbus
+                    case 3:
+                        lnfName = "com.sun.java.swing.plaf.motif.MotifLookAndFeel";
+                        break; // Motif
+                    case 4:
+                        lnfName = "com.sun.java.swing.plaf.gtk.GTKLookAndFeel";
+                        break; // GTK
+                    case 5:
+                        lnfName = "com.sun.java.swing.plaf.windows.WindowsLookAndFeel";
+                        break; // Windows
+                    default:
+                        lnfName = "";
+                }
+                UIManager.setLookAndFeel(lnfName);
                 SwingUtilities.updateComponentTreeUI(frame);
                 frame.pack();
                 // Apply to all instances of JChemPaint
@@ -506,41 +422,44 @@ public class PropertiesModelEditor extends FieldTablePanel implements ActionList
                 }
                 props.setProperty("LookAndFeel", String.valueOf(lookAndFeel.getSelectedIndex()));
                 props.setProperty("LookAndFeelClass", lnfName);
-		    }
-            catch (UnsupportedLookAndFeelException e) {
-	    	    JOptionPane.showMessageDialog(this, GT.get("Look and feel")+" \""+lookAndFeel.getSelectedItem()+"\" "+GT.get("is not supported on this platform"),GT.get("Unsupported look&feel"), JOptionPane.WARNING_MESSAGE);
-            }
-            catch (ClassNotFoundException e) {
-                JOptionPane.showMessageDialog(this, GT.get("Class not found:")+" "+ lnfName);
-            }
-            catch (InstantiationException e) {
-            // handle exception
-	    	    JOptionPane.showMessageDialog(this, GT.get("Instantiation Exception:")+" "+ lnfName);
-            }
-            catch (IllegalAccessException e) {
+            } catch (UnsupportedLookAndFeelException e) {
+                JOptionPane.showMessageDialog(this, GT.get("Look and feel") + " \"" + lookAndFeel.getSelectedItem() + "\" " + GT.get("is not supported on this platform"), GT.get("Unsupported look&feel"), JOptionPane.WARNING_MESSAGE);
+            } catch (ClassNotFoundException e) {
+                JOptionPane.showMessageDialog(this, GT.get("Class not found:") + " " + lnfName);
+            } catch (InstantiationException e) {
+                // handle exception
+                JOptionPane.showMessageDialog(this, GT.get("Instantiation Exception:") + " " + lnfName);
+            } catch (IllegalAccessException e) {
                 JOptionPane.showMessageDialog(this, GT.get("Illegal Access: ") + lnfName);
             }
         }
 
+        jcpPanel.getRenderPanel()
+                .updateDisplayOptions();
+
         JCPPropertyHandler.getInstance(true).saveProperties();
         boolean languagechanged = false;
-        for(int i=0;i<gtlanguages.length;i++){
-            if(gtlanguages[i].language.equals((String)language.getSelectedItem())){
-                if(props.getProperty("General.language")==null || 
-                  !props.getProperty("General.language").equals(gtlanguages[i].code)){
-                    props.setProperty("General.language", gtlanguages[i].code);
+        for (GT.Language gtlanguage : gtlanguages) {
+            if (gtlanguage.language.equals((String) language.getSelectedItem())) {
+                // en_US/en_GB ~ en (startsWith)
+                String currentLanguage = props.getProperty("General.language");
+                if (currentLanguage == null || !gtlanguage.code.startsWith(currentLanguage)) {
+                    props.setProperty("General.language", gtlanguage.code);
                     languagechanged = true;
                 }
+                break;
             }
         }
+
         JCPPropertyHandler.getInstance(true).saveProperties();
-        if(languagechanged && !close){
+        if (languagechanged && !close) {
             //we need to rediplay the dialog to change its language
             this.getParent().getParent().getParent().getParent().setVisible(false);
-            JChemPaintRendererModel renderModel = 
-                jcpPanel.get2DHub().getRenderer().getRenderer2DModel();
+            JChemPaintRendererModel renderModel =
+                    jcpPanel.get2DHub().getRenderer().getRenderer2DModel();
             ModifyRenderOptionsDialog frame =
-                    new ModifyRenderOptionsDialog(jcpPanel,renderModel, 1);
+                    new ModifyRenderOptionsDialog(jcpPanel, renderModel,
+                                                  tabbedPane.getSelectedIndex());
             frame.setVisible(true);
         }
     }
@@ -573,7 +492,7 @@ public class PropertiesModelEditor extends FieldTablePanel implements ActionList
                 color.setBackground(currentColor);
             }
         }
-    }     
+    }
 }
 
 

--- a/core/src/main/resources/org/openscience/jchempaint/resources/JChemPaintResources.properties
+++ b/core/src/main/resources/org/openscience/jchempaint/resources/JChemPaintResources.properties
@@ -370,4 +370,5 @@ ShowImplicitHydrogens=true
 DrawNumbers=false
 WedgeWidth=6.0
 HashSpacing=3.25
+BondSeparation=0.18
 ShowReactionBoxes=false

--- a/core/src/main/resources/org/openscience/jchempaint/resources/JChemPaintResources.properties
+++ b/core/src/main/resources/org/openscience/jchempaint/resources/JChemPaintResources.properties
@@ -370,5 +370,5 @@ ShowImplicitHydrogens=true
 DrawNumbers=false
 WedgeWidth=6.0
 HashSpacing=3.25
-BondSeparation=0.18
+BondSpacing=0.18
 ShowReactionBoxes=false

--- a/core/src/main/resources/org/openscience/jchempaint/resources/JChemPaintResources.properties
+++ b/core/src/main/resources/org/openscience/jchempaint/resources/JChemPaintResources.properties
@@ -368,5 +368,6 @@ ShowEndCarbons=true
 ShowExplicitHydrogens=true
 ShowImplicitHydrogens=true
 DrawNumbers=false
-WedgeWidth=5.0
+WedgeWidth=6.0
+HashSpacing=3.25
 ShowReactionBoxes=false

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <cdk.version>2.11</cdk.version>
+        <cdk.version>2.12-SNAPSHOT</cdk.version>
     </properties>
 
     <prerequisites>

--- a/render/src/main/java/org/openscience/jchempaint/renderer/JChemPaintRendererModel.java
+++ b/render/src/main/java/org/openscience/jchempaint/renderer/JChemPaintRendererModel.java
@@ -37,6 +37,7 @@ import org.openscience.cdk.renderer.generators.BasicAtomGenerator;
 import org.openscience.cdk.renderer.generators.BasicBondGenerator;
 import org.openscience.cdk.renderer.generators.BasicSceneGenerator;
 import org.openscience.cdk.renderer.generators.RingGenerator;
+import org.openscience.cdk.renderer.generators.standard.StandardGenerator;
 import org.openscience.cdk.renderer.selection.IChemObjectSelection;
 
 import javax.vecmath.Point2d;
@@ -167,14 +168,25 @@ public class JChemPaintRendererModel extends RendererModel implements Serializab
     }
 
     public double getWedgeWidth() {
-        if (hasParameter(BasicBondGenerator.WedgeWidth.class))
-            return get(BasicBondGenerator.WedgeWidth.class);
-        return new BasicBondGenerator.WedgeWidth().getDefault();
+        if (hasParameter(StandardGenerator.WedgeRatio.class))
+            return get(StandardGenerator.WedgeRatio.class);
+        return new StandardGenerator.WedgeRatio().getDefault();
     }
 
     public void setWedgeWidth(double wedgeWidth) {
-        if (hasParameter(BasicBondGenerator.WedgeWidth.class))
-            set(BasicBondGenerator.WedgeWidth.class, wedgeWidth);
+        if (hasParameter(StandardGenerator.WedgeRatio.class))
+            set(StandardGenerator.WedgeRatio.class, wedgeWidth);
+    }
+
+    public double getHashSpacing() {
+        if (hasParameter(StandardGenerator.HashSpacing.class))
+            return get(StandardGenerator.HashSpacing.class);
+        return new StandardGenerator.HashSpacing().getDefault();
+    }
+
+    public void setHashSpacing(double wedgeWidth) {
+        if (hasParameter(StandardGenerator.HashSpacing.class))
+            set(StandardGenerator.HashSpacing.class, wedgeWidth);
     }
 
     public double getRingProportion() {
@@ -351,9 +363,9 @@ public class JChemPaintRendererModel extends RendererModel implements Serializab
      * @return the thickness of a bond line
      */
     public double getBondWidth() {
-        if (hasParameter(BasicBondGenerator.BondWidth.class))
-            return get(BasicBondGenerator.BondWidth.class);
-        return new BasicBondGenerator.BondWidth().getDefault();
+        if (hasParameter(StandardGenerator.StrokeRatio.class))
+            return get(StandardGenerator.StrokeRatio.class);
+        return new StandardGenerator.StrokeRatio().getDefault();
     }
 
     /**
@@ -363,8 +375,31 @@ public class JChemPaintRendererModel extends RendererModel implements Serializab
      *            the thickness of a bond line
      */
     public void setBondWidth(double bondWidth) {
-        if (hasParameter(BasicBondGenerator.BondWidth.class))
-            set(BasicBondGenerator.BondWidth.class, bondWidth);
+        if (hasParameter(StandardGenerator.StrokeRatio.class))
+            set(StandardGenerator.StrokeRatio.class, bondWidth);
+    }
+
+
+    /**
+     * Returns the thickness of a bond line.
+     *
+     * @return the thickness of a bond line
+     */
+    public double getBondSeparation() {
+        if (hasParameter(StandardGenerator.BondSeparation.class))
+            return get(StandardGenerator.BondSeparation.class);
+        return new StandardGenerator.BondSeparation().getDefault();
+    }
+
+    /**
+     * Sets the thickness of a bond line.
+     *
+     * @param bondSeparation
+     *            the thickness of a bond line
+     */
+    public void setBondSeparation(double bondSeparation) {
+        if (hasParameter(StandardGenerator.BondSeparation.class))
+            set(StandardGenerator.BondSeparation.class, bondSeparation);
     }
 
     /**


### PR DESCRIPTION
Hmm looks like this didn't post, need to merge #217 first and the CDK one (https://github.com/cdk/cdk/pull/1215) and then this is a single (albeit large) commit.

It overhauls and updates the preferences to work with the new depictions.
I've removed some options which don't make sense and added some others. I have disabled two options I want to add back in but need to think about. We do already support both but they need a bit more thought on how they work.

Color Atoms:
<img width="830" height="363" alt="Screenshot 2025-08-23 at 09 17 48" src="https://github.com/user-attachments/assets/f4f55b6b-f7c8-4397-ba1a-f01804cf2a50" />
Terminal Carbons:
<img width="823" height="341" alt="Screenshot 2025-08-23 at 09 17 55" src="https://github.com/user-attachments/assets/9403a2d9-c0b4-4c7b-8276-718f12bb64fa" />
All Carbons:
<img width="819" height="347" alt="Screenshot 2025-08-23 at 09 18 00" src="https://github.com/user-attachments/assets/c370551d-79ac-4de4-afd9-51c33024196f" />
Bond Width:
<img width="828" height="359" alt="Screenshot 2025-08-23 at 09 18 21" src="https://github.com/user-attachments/assets/5b9b5d9e-9acc-4273-b6aa-6fd9ee7dbec7" />
Wedge Width:
<img width="827" height="348" alt="Screenshot 2025-08-23 at 09 18 35" src="https://github.com/user-attachments/assets/4fff44b6-5f1e-45d3-b423-9595d01173bb" />


