### PR TITLE
Setup macOS codesigning

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -64,21 +64,38 @@ jobs:
           java-version: 17
           cache: maven
 
+      - name: Import signing certificate
+        run: |
+          echo "${{ secrets.MACOS_DEVELOPER_CERTIFICATE_BASE64 }}" | base64 --decode > build.p12
+          security create-keychain -p build build.keychain
+          security default-keychain -s build.keychain
+          security unlock-keychain -p build build.keychain
+          security import build.p12 -k build.keychain -P "${{ secrets.MACOS_DEVELOPER_CERTIFICATE_PASSWORD }}" -T /usr/bin/codesign >/dev/null 2>&1
+          security set-key-partition-list -S apple-tool:,apple: -s -k build build.keychain >/dev/null 2>&1
+          rm -fr build.p12
+
       - name: Package Disk Image
         env:
-          MACOS_DEVELOPER_IDENTITY: ${{ secrets.MACOS_DEVELOPER_IDENTITY }}
-          MACOS_DEVELOPER_CERTIFICATE_BASE64: ${{ secrets.MACOS_DEVELOPER_CERTIFICATE_BASE64 }}
-          MACOS_DEVELOPER_CERTIFICATE_PASSWORD: ${{ secrets.MACOS_DEVELOPER_CERTIFICATE_PASSWORD }}
-          MACOS_DEVELOPER_USERNAME: ${{ secrets.MACOS_DEVELOPER_USERNAME }}
-          MACOS_DEVELOPER_PASSWORD: ${{ secrets.MACOS_DEVELOPER_PASSWORD }}
           MAVEN_ARGS: "--batch-mode --no-transfer-progress -Dstyle.color=always"
         run: |
-          mvn install -DskipTests -Posx-app
+          mvn install -DskipTests -Posx-app -Dcodesign.identity="${{ secrets.MACOS_DEVELOPER_IDENTITY }}"
+          mv app-osx/target/*.dmg JChemPaint.dmg
+
+        # Fails because the step above does not codesign the included native dependencies.
+      - name: Notarize
+        if: false
+        run: |
+          xcrun notarytool submit JChemPaint.dmg --wait --apple-id "${{ secrets.MACOS_DEVELOPER_USERNAME }}" --password "${{ secrets.MACOS_DEVELOPER_PASSWORD }}" --team-id "${{ secrets.MACOS_DEVELOPER_IDENTITY }}" > result.txt 2>&1
+          SUBMISSION_ID=`awk '/id: / { print $2;exit; }' result.txt`
+          xcrun notarytool log "$SUBMISSION_ID" --apple-id ${{ secrets.MACOS_DEVELOPER_USERNAME }} --password ${{ secrets.MACOS_DEVELOPER_PASSWORD }} --team-id ${{ secrets.MACOS_DEVELOPER_IDENTITY }} log.json
+          cat log.json
+
+          xcrun stapler staple JChemPaint.dmg
+          xcrun stapler validate JChemPaint.dmg
 
       - name: Upload Package
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: bash
         run: |
-          mv app-osx/target/*.dmg app-osx/target/JChemPaint.dmg
-          gh release upload nightly app-osx/target/*.dmg
+          gh release upload nightly JChemPaint.dmg

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -33,10 +33,12 @@ jobs:
           java-version: 17
           cache: maven
 
-      - name: Install gettext      
+      - name: Install gettext
         run: sudo apt install -y gettext
 
       - name: Package JAR
+        env:
+          MAVEN_ARGS: "--batch-mode --no-transfer-progress -Dstyle.color=always"
         run: |
           mvn install -DskipTests
 
@@ -69,6 +71,7 @@ jobs:
           MACOS_DEVELOPER_CERTIFICATE_PASSWORD: ${{ secrets.MACOS_DEVELOPER_CERTIFICATE_PASSWORD }}
           MACOS_DEVELOPER_USERNAME: ${{ secrets.MACOS_DEVELOPER_USERNAME }}
           MACOS_DEVELOPER_PASSWORD: ${{ secrets.MACOS_DEVELOPER_PASSWORD }}
+          MAVEN_ARGS: "--batch-mode --no-transfer-progress -Dstyle.color=always"
         run: |
           mvn install -DskipTests -Posx-app
 

--- a/app-osx/pom.xml
+++ b/app-osx/pom.xml
@@ -38,6 +38,9 @@
                       <dmg>
                         <generate>true</generate>
                       </dmg>
+                      <codesign>
+                        <identity>${codesign.identity}</identity>
+                      </codesign>
                     </configuration>
                     <executions>
                       <execution>


### PR DESCRIPTION
Note that notarization currently fails because the dependencies are not code-signed and the Maven plug-in does not sign them either. It needs to be patched or replaced. Disabled the notarization step until it is solved.

<details>
  <summary>Apple notarisation response</summary>

```json
{
  "logFormatVersion": 1,
  "jobId": "cd1eeddc-cb39-4e10-b82b-402527057ba3",
  "status": "Invalid",
  "statusSummary": "Archive contains critical validation errors",
  "statusCode": 4000,
  "archiveFilename": "JChemPaint.dmg",
  "uploadDate": "2025-10-01T17:08:19.658Z",
  "sha256": "12a97385ff8865c87bb21616032a78eb9a23b6168fc3e872f25578f2940ba7c8",
  "ticketContents": null,
  "issues": [
    {
      "severity": "error",
      "code": null,
      "path": "JChemPaint.dmg/JChemPaint.app/Contents/Java/classpath/net/java/dev/jna/jna/5.10.0/jna-5.10.0.jar/com/sun/jna/darwin-aarch64/libjnidispatch.jnilib",
      "message": "The binary is not signed with a valid Developer ID certificate.",
      "docUrl": "https://developer.apple.com/documentation/security/notarizing_macos_software_before_distribution/resolving_common_notarization_issues#3087721",
      "architecture": "arm64"
    },
    {
      "severity": "error",
      "code": null,
      "path": "JChemPaint.dmg/JChemPaint.app/Contents/Java/classpath/net/java/dev/jna/jna/5.10.0/jna-5.10.0.jar/com/sun/jna/darwin-aarch64/libjnidispatch.jnilib",
      "message": "The signature does not include a secure timestamp.",
      "docUrl": "https://developer.apple.com/documentation/security/notarizing_macos_software_before_distribution/resolving_common_notarization_issues#3087733",
      "architecture": "arm64"
    },
    {
      "severity": "error",
      "code": null,
      "path": "JChemPaint.dmg/JChemPaint.app/Contents/Java/classpath/net/java/dev/jna/jna/5.10.0/jna-5.10.0.jar/com/sun/jna/darwin-x86-64/libjnidispatch.jnilib",
      "message": "The binary is not signed.",
    },
    {
      "severity": "error",
      "code": null,
      "path": "JChemPaint.dmg/JChemPaint.app/Contents/Java/classpath/io/github/dan2097/jna-inchi-darwin-x86-64/1.3.1/jna-inchi-darwin-x86-64-1.3.1.jar/darwin-x86-64/libjnainchi.dylib",
      "message": "The signature does not include a secure timestamp.",
      "docUrl": "https://developer.apple.com/documentation/security/notarizing_macos_software_before_distribution/resolving_common_notarization_issues#3087733",
      "architecture": "x86_64"
    },
    {
      "severity": "error",
      "code": null,
      "path": "JChemPaint.dmg/JChemPaint.app/Contents/Java/classpath/com/formdev/flatlaf/3.6.1/flatlaf-3.6.1.jar/com/formdev/flatlaf/natives/libflatlaf-macos-x86_64.dylib",
      "message": "The binary is not signed with a valid Developer ID certificate.",
      "docUrl": "https://developer.apple.com/documentation/security/notarizing_macos_software_before_distribution/resolving_common_notarization_issues#3087721",
      "architecture": "x86_64"
    },
    {
      "severity": "error",
      "code": null,
      "path": "JChemPaint.dmg/JChemPaint.app/Contents/Java/classpath/com/formdev/flatlaf/3.6.1/flatlaf-3.6.1.jar/com/formdev/flatlaf/natives/libflatlaf-macos-arm64.dylib",
      "message": "The binary is not signed with a valid Developer ID certificate.",
      "docUrl": "https://developer.apple.com/documentation/security/notarizing_macos_software_before_distribution/resolving_common_notarization_issues#3087721",
      "architecture": "arm64"
    },
    {
      "severity": "error",
      "code": null,
      "path": "JChemPaint.dmg/JChemPaint.app/Contents/MacOS/JavaLauncher",
      "message": "The executable does not have the hardened runtime enabled.",
      "docUrl": "https://developer.apple.com/documentation/security/notarizing_macos_software_before_distribution/resolving_common_notarization_issues#3087724",
      "architecture": "x86_64"
    },
    {
      "severity": "error",
      "code": null,
      "path": "JChemPaint.dmg/JChemPaint.app/Contents/MacOS/JavaLauncher",
      "message": "The executable does not have the hardened runtime enabled.",
      "docUrl": "https://developer.apple.com/documentation/security/notarizing_macos_software_before_distribution/resolving_common_notarization_issues#3087724",
      "architecture": "arm64"
    }
  ]
}
```
</details>

Test build https://github.com/Mailaender/jchempaint/actions/runs/18170007228
Test package https://github.com/Mailaender/jchempaint/releases/tag/nightly